### PR TITLE
Adds support to ARM64 with buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,17 @@ RUN apk add --no-cache \
 ARG NGINX=1.19.5
 ARG GEOIP_MOD=3.3
 ARG GEOIPUPDATE=4.5.0
+ARG TARGETARCH
 ## Download required packages
 RUN wget https://github.com/leev/ngx_http_geoip2_module/archive/${GEOIP_MOD}.tar.gz \
-    && wget https://github.com/maxmind/geoipupdate/releases/download/v${GEOIPUPDATE}/geoipupdate_${GEOIPUPDATE}_linux_amd64.tar.gz \
+    && wget https://github.com/maxmind/geoipupdate/releases/download/v${GEOIPUPDATE}/geoipupdate_${GEOIPUPDATE}_linux_${TARGETARCH}.tar.gz \
     && wget http://nginx.org/download/nginx-${NGINX}.tar.gz
 
 ## Unpack all the downloaded tarballs files
 RUN tar zxvf ${GEOIP_MOD}.tar.gz \
     && tar zxvf nginx-${NGINX}.tar.gz \
-    && tar zxvf geoipupdate_${GEOIPUPDATE}_linux_amd64.tar.gz \
-    && cp /geoipupdate_${GEOIPUPDATE}_linux_amd64/geoipupdate /usr/local/bin/ \
+    && tar zxvf geoipupdate_${GEOIPUPDATE}_linux_${TARGETARCH}.tar.gz \
+    && cp /geoipupdate_${GEOIPUPDATE}_linux_${TARGETARCH}/geoipupdate /usr/local/bin/ \
     && rm -rf *.tar.gz
 
 ## Compile and Install Nginx with GeoIP module.
@@ -36,7 +37,7 @@ RUN  cd nginx-${NGINX} && ./configure \
 
 ## Clean up to reduce image size
 RUN apk del zlib-dev g++ make \
-    && rm -rf geoipupdate_${GEOIPUPDATE}_linux_amd64 \
+    && rm -rf geoipupdate_${GEOIPUPDATE}_linux_${TARGETARCH} \
     && rm -rf nginx-${NGINX} \
     && rm -rf ngx_http_geoip2_module-${GEOIP_MOD}
 

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,10 @@ help: ## Prints this help.
 	echo $(VERSION) ${VERSION}
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-build: ## Build the docker image
-	@docker build \
+build-multi-arch: ## Build the docker image for multiple architectures
+	docker buildx build \
+		--platform=linux/amd64,linux/arm64 \
+		--push \
 		--build-arg NGINX=$(NGINX) \
 		--build-arg GEOIP_MOD=$(GEOIP_MOD) \
 		--build-arg GEOIPUPDATE=$(GEOIPUPDATE) \


### PR DESCRIPTION
Hola @erusso7, long time no see, espero que te encuentres bien 😃!

Sending this small PR to add support to ARM64 architecture for this image, you should be able to build this with a Docker Desktop setup.

I tested it on our infra and the images seem to work fine:

```bash
$ curl -H 'x-forwarded-for: 37.223.5.39' http://127.0.0.1:1234
{"ip":"37.223.5.39","continent": {"id": "6255148","code": "EU","name": "Europe"},"country": {"id": "2510769","code": "ES","name": "Spain"},"city": {"id": "3128760","name": "Barcelona"},"location": {"accuracy_radius": "10","latitude": "41.43530","longitude": "2.21040","time_zone": "Europe/Madrid"}}%
```